### PR TITLE
Prevent AccessControlException when running with active SecurityManager

### DIFF
--- a/src/com/unboundid/util/Debug.java
+++ b/src/com/unboundid/util/Debug.java
@@ -215,7 +215,12 @@ public final class Debug
     debugEnabled      = false;
     debugTypes        = EnumSet.allOf(DebugType.class);
 
-    logger.setLevel(Level.ALL);
+    try {
+      logger.setLevel(Level.ALL);
+    }
+    catch (final Exception e) {
+      //
+    }
   }
 
 
@@ -309,7 +314,13 @@ public final class Debug
     final String levelProp = properties.getProperty(PROPERTY_DEBUG_LEVEL);
     if ((levelProp != null) && (! levelProp.isEmpty()))
     {
-      logger.setLevel(Level.parse(levelProp));
+    	try {
+          logger.setLevel(Level.parse(levelProp));
+    	}
+    	catch (final Exception e) {
+    	  logger.log(Level.WARNING, "Could not change log level to "+
+    	    levelProp, e);
+    	}
     }
   }
 

--- a/src/com/unboundid/util/StaticUtils.java
+++ b/src/com/unboundid/util/StaticUtils.java
@@ -123,17 +123,15 @@ public final class StaticUtils
     // Try to dynamically determine the size of the terminal window using the
     // COLUMNS environment variable.
     int terminalWidth = 80;
-    final String columnsEnvVar = System.getenv("COLUMNS");
-    if (columnsEnvVar != null)
-    {
-      try
-      {
+    try {
+      final String columnsEnvVar = System.getenv("COLUMNS");
+      if (columnsEnvVar != null) {
         terminalWidth = Integer.parseInt(columnsEnvVar);
       }
-      catch (final Exception e)
-      {
-        Debug.debugException(e);
-      }
+    }
+    catch (final Exception e)
+    {
+      Debug.debugException(e);
     }
 
     TERMINAL_WIDTH_COLUMNS = terminalWidth;


### PR DESCRIPTION
I tried to use UnboundId in an IBM Notes/Domino environment which has a restrictive SecurityManager in place (Java agent in an NSF database).
Had to catch AccessControlExceptions in two classes to make it work.